### PR TITLE
Improve stack shim performance

### DIFF
--- a/CodeParser/Kernel/Abstract.wl
+++ b/CodeParser/Kernel/Abstract.wl
@@ -447,10 +447,6 @@ Module[{abstracted, issues, issues1, issues2, data, abstractedChildren, node, re
 
 	children = childrenIn;
 
-	If[Length[children] > $TopLevelExpressionLimit,
-		Throw[Failure["TooManyTopLevelExpressions", <||>]]
-	];
-
 	data = dataIn;
 
 	reportIssues = (tag === File);


### PR DESCRIPTION
Use nested tuple instead of AppendTo to improve the top-level expression abstraction.
The old implementation takes O(n) for Push, and Pop, and O(1) for Normal,
while the new implementation takes O(1) for Push, and Pop, and O(n) for Normal.
This accelerates the `abstractTopLevel` function since it contains n pushes and pops and m normalizations of size n/m.
Thus, this change improves it from O(n^2) to O(n), which is efficient enough to remove the $TopLevelExpressionLimit.

This can be verified by running following tests:

AppendTo
![image](https://user-images.githubusercontent.com/8650023/79034847-f5942580-7b6d-11ea-8a23-d79ca860b4f9.png)

Nested Tuple:
![image](https://user-images.githubusercontent.com/8650023/79035118-342adf80-7b70-11ea-95d2-1b00e00ccf58.png)

__Update:__ thanks to @szhorvat's reminding me of using a custom head, the `Normal` is now ~30x faster.

![image](https://user-images.githubusercontent.com/8650023/79193010-a30d7000-7dde-11ea-9108-1ea97f6f9d61.png)

