### PR TITLE
add double quotes to installation path for Mathematica

### DIFF
--- a/HowToBuild.md
+++ b/HowToBuild.md
@@ -7,6 +7,7 @@ CodeParser uses C++11 features and requires a compiler that can support at least
 CodeParser uses CMake to generate build scripts.
 
 Here is an example transcript using the default make generator to build CodeParser:
+
 ```
 cd codeparser
 mkdir build
@@ -14,10 +15,19 @@ cd build
 cmake ..
 cmake --build . --target paclet
 ```
+
 The result is a directory named `paclet` that contains the WL package source code and a built CodeParser `.paclet` file for installing.
 
 Specify `MATHEMATICA_INSTALL_DIR` if you have Mathematica installed in a non-default location:
+
 ```
 cmake -DMATHEMATICA_INSTALL_DIR=/Applications/Mathematica111.app/Contents/ ..
+cmake --build . --target paclet
+```
+
+On Windows:
+
+```
+cmake -DMATHEMATICA_INSTALL_DIR="C:/Program Files/Wolfram Research/Mathematica/12.0" ..
 cmake --build . --target paclet
 ```

--- a/cmake/WolframKernel.cmake
+++ b/cmake/WolframKernel.cmake
@@ -1,7 +1,7 @@
 
 if(NOT DEFINED MATHEMATICA_INSTALL_DIR)
 if(CMAKE_HOST_WIN32 OR CYGWIN)
-	set(MATHEMATICA_INSTALL_DIR C:/Program Files/Wolfram Research/Mathematica/12.0)
+	set(MATHEMATICA_INSTALL_DIR "C:/Program Files/Wolfram Research/Mathematica/12.0")
 elseif(CMAKE_HOST_APPLE)
 	set(MATHEMATICA_INSTALL_DIR /Applications/Mathematica.app/Contents)
 else()


### PR DESCRIPTION
fixes #12 