### PR TITLE
[Action] Use scripts instead of docker.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,36 +6,53 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+
+env:
+  WOLFRAM_ID: ${{ secrets.WOLFRAM_ID }}
+  WOLFRAM_PW: ${{ secrets.WOLFRAM_PW }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: "Build Code Parser"
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a single command using the runners shell
-    - name: Run a one-line script
-      run: echo Hello, world!
-
-    # Runs a set of commands using the runners shell
-    - name: Run a multi-line script
+    - name: Install Dependencies
       run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
-    
-    # Build CodeParser
+        sudo apt update
+        sudo apt install -y wget cmake
+
+    - name: Install Wolfram Engine
+      run: |
+        wget https://account.wolfram.com/download/public/wolfram-engine/desktop/LINUX
+        sudo bash LINUX -- -auto -verbose
+        rm LINUX
+
+    - name: Activate Wolfram Engine
+      run: |
+        /usr/bin/wolframscript -authenticate $WOLFRAM_ID $WOLFRAM_PW
+        /usr/bin/wolframscript -activate
+
     - name: Build CodeParser
-      uses: lukka/run-cmake@v2
-      with:
-        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
-        cmakeListsTxtPath: '${{github.workspace}}/CMakeLists.txt'
-        buildDirectory: '${{runner.workspace}}/build'
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DMATHEMATICA_INSTALL_DIR="/usr/local/Wolfram/WolframEngine/12.1"
+        cmake --build . --target paclet
+
+    - name: Install Paclet
+      # TODO: find a way to specify the name of the paclet file instead of hardcoding.
+      run: |
+        ls build
+        /usr/bin/wolframscript -code 'PacletInstall["./build/paclet/CodeParser-1.1.paclet"];Exit[]'


### PR DESCRIPTION
It turns out that the [github-action-for-wolfram-language](https://github.com/marketplace/actions/github-action-for-wolfram-language) is a standalone docker that all the steps which follow it cannot access its file. So I manually scripted the commands. 

This PR will be pushed to your `bostick-patch-1` branch first, so you can continue to add the next step to run tests and parse the test results (which I guess will be nasty) after `Install Paclet`.

Once the whole action workflow is finished on that branch, we can merge #19 to `master`.